### PR TITLE
Add free setup building

### DIFF
--- a/code/catanGame.py
+++ b/code/catanGame.py
@@ -114,7 +114,8 @@ class catanGame():
 
             roadToBuild = self.boardView.buildRoad_display(player, potentialRoadDict)
             if(roadToBuild != None):
-                player.build_road(roadToBuild[0], roadToBuild[1], self.board)
+                player.build_road(roadToBuild[0], roadToBuild[1], self.board,
+                                 free=self.gameSetup)
 
             
         if(build_flag == 'SETTLE'): #Show screen with potential settlements
@@ -125,7 +126,8 @@ class catanGame():
             
             vertexSettlement = self.boardView.buildSettlement_display(player, potentialVertexDict)
             if(vertexSettlement != None):
-                player.build_settlement(vertexSettlement, self.board) 
+                player.build_settlement(vertexSettlement, self.board,
+                                       free=self.gameSetup)
 
         if(build_flag == 'CITY'): 
             potentialCityVertexDict = self.board.get_potential_cities(player)

--- a/code/heuristicAIPlayer.py
+++ b/code/heuristicAIPlayer.py
@@ -56,13 +56,16 @@ class heuristicAIPlayer(player):
             if(resourceType not in self.setupResources and resourceType != 'DESERT'):
                 self.setupResources.append(resourceType)
 
-        self.build_settlement(vertexToBuild, board)
+        #Free placement during initial setup
+        self.build_settlement(vertexToBuild, board, free=True)
 
 
         #Build random road
         possibleRoads = board.get_setup_roads(self)
         randomEdge = np.random.randint(0, len(possibleRoads.keys()))
-        self.build_road(list(possibleRoads.keys())[randomEdge][0], list(possibleRoads.keys())[randomEdge][1], board)
+        self.build_road(list(possibleRoads.keys())[randomEdge][0],
+                        list(possibleRoads.keys())[randomEdge][1],
+                        board, free=True)
 
     
     def move(self, board):

--- a/code/player.py
+++ b/code/player.py
@@ -18,7 +18,9 @@ class player():
         self.settlementsLeft = 5
         self.roadsLeft = 15
         self.citiesLeft = 4
-        self.resources = {'ORE':5, 'BRICK':6, 'WHEAT':3, 'WOOD':6, 'SHEEP':3} #Dictionary that keeps track of resource amounts
+        #Resource pool for the player. Players begin with no resources and gain
+        #their starting cards after the initial settlement placement phase.
+        self.resources = {'ORE':0, 'BRICK':0, 'WHEAT':0, 'WOOD':0, 'SHEEP':0}
 
         self.knightsPlayed = 0
         self.largestArmyFlag = False
@@ -42,17 +44,22 @@ class player():
 
 
     #function to build a road from vertex v1 to vertex v2
-    def build_road(self, v1, v2, board):
-        'Update buildGraph to add a road on edge v1 - v2'
+    def build_road(self, v1, v2, board, free=False):
+        """Add a road on edge ``v1``-``v2``.
 
-        if(self.resources['BRICK'] > 0 and self.resources['WOOD'] > 0): #Check if player has resources available
-            if(self.roadsLeft > 0): #Check if player has roads left
-                self.buildGraph['ROADS'].append((v1,v2))
+        When ``free`` is ``True`` (during the initial setup phase) no
+        resource check or deduction is performed.
+        """
+
+        if free or (self.resources['BRICK'] > 0 and self.resources['WOOD'] > 0):
+            if self.roadsLeft > 0:  # Check if player has roads left
+                self.buildGraph['ROADS'].append((v1, v2))
                 self.roadsLeft -= 1
 
-                #Update player resources
-                self.resources['BRICK'] -= 1
-                self.resources['WOOD'] -= 1
+                #Update player resources only when not building for free
+                if not free:
+                    self.resources['BRICK'] -= 1
+                    self.resources['WOOD'] -= 1
 
                 board.updateBoardGraph_road(v1, v2, self) #update the overall boardGraph
 
@@ -70,22 +77,24 @@ class player():
 
 
     #function to build a settlement on vertex with coordinates vCoord
-    def build_settlement(self, vCoord, board):
-        'Update player buildGraph and boardgraph to add a settlement on vertex v'
-        #Take input from Player on where to build settlement
-            #Check if player has correct resources
-                #Update player resources and boardGraph with transaction
+    def build_settlement(self, vCoord, board, free=False):
+        """Place a settlement on ``vCoord``.
 
-        if(self.resources['BRICK'] > 0 and self.resources['WOOD'] > 0 and self.resources['SHEEP'] > 0 and self.resources['WHEAT'] > 0): #Check if player has resources available
-            if(self.settlementsLeft > 0): #Check if player has settlements left
+        If ``free`` is ``True`` the placement does not cost any resources.
+        """
+
+        if free or (self.resources['BRICK'] > 0 and self.resources['WOOD'] > 0 and
+                     self.resources['SHEEP'] > 0 and self.resources['WHEAT'] > 0):
+            if self.settlementsLeft > 0:
                 self.buildGraph['SETTLEMENTS'].append(vCoord)
                 self.settlementsLeft -= 1
 
                 #Update player resources
-                self.resources['BRICK'] -= 1
-                self.resources['WOOD'] -= 1
-                self.resources['SHEEP'] -= 1
-                self.resources['WHEAT'] -= 1
+                if not free:
+                    self.resources['BRICK'] -= 1
+                    self.resources['WOOD'] -= 1
+                    self.resources['SHEEP'] -= 1
+                    self.resources['WHEAT'] -= 1
                 
                 self.victoryPoints += 1
                 board.updateBoardGraph_settlement(vCoord, self) #update the overall boardGraph


### PR DESCRIPTION
## Summary
- start players with no resources
- allow roads and settlements to be placed for free during setup
- use the free-build logic in AI setup and game initialization

## Testing
- `python -m py_compile code/player.py code/catanGame.py code/heuristicAIPlayer.py`

------
https://chatgpt.com/codex/tasks/task_e_6852e3e7787c83259b1eefed4de27686