### PR TITLE
Fix devcard count

### DIFF
--- a/code/AIGame.py
+++ b/code/AIGame.py
@@ -118,16 +118,22 @@ class catanAIGame():
                     for adjacentHex in self.board.boardGraph[settlementCoord].adjacentHexList: #check each adjacent hex to a settlement
                         if(adjacentHex in hexResourcesRolled and self.board.hexTileDict[adjacentHex].robber == False): #This player gets a resource if hex is adjacent and no robber
                             resourceGenerated = self.board.hexTileDict[adjacentHex].resource.type
-                            player_i.resources[resourceGenerated] += 1
-                            print("{} collects 1 {} from Settlement".format(player_i.name, resourceGenerated))
+                            if self.board.withdraw_resource(resourceGenerated):
+                                player_i.resources[resourceGenerated] += 1
+                                print("{} collects 1 {} from Settlement".format(player_i.name, resourceGenerated))
                 
                 #Check each City the player has
                 for cityCoord in player_i.buildGraph['CITIES']:
                     for adjacentHex in self.board.boardGraph[cityCoord].adjacentHexList: #check each adjacent hex to a settlement
                         if(adjacentHex in hexResourcesRolled and self.board.hexTileDict[adjacentHex].robber == False): #This player gets a resource if hex is adjacent and no robber
                             resourceGenerated = self.board.hexTileDict[adjacentHex].resource.type
-                            player_i.resources[resourceGenerated] += 2
-                            print("{} collects 2 {} from City".format(player_i.name, resourceGenerated))
+                            gained = 0
+                            for _ in range(2):
+                                if self.board.withdraw_resource(resourceGenerated):
+                                    player_i.resources[resourceGenerated] += 1
+                                    gained += 1
+                            if gained:
+                                print("{} collects {} {} from City".format(player_i.name, gained, resourceGenerated))
 
                 print("Player:{}, Resources:{}, Points: {}".format(player_i.name, player_i.resources, player_i.victoryPoints))
                 #print('Dev Cards:{}'.format(player_i.devCards))
@@ -246,4 +252,5 @@ class catanAIGame():
                                    
 
 #Initialize new game and run
-newGame_AI = catanAIGame()
+if __name__ == '__main__':
+    newGame_AI = catanAIGame()

--- a/code/catanGame.py
+++ b/code/catanGame.py
@@ -170,16 +170,22 @@ class catanGame():
                     for adjacentHex in self.board.boardGraph[settlementCoord].adjacentHexList: #check each adjacent hex to a settlement
                         if(adjacentHex in hexResourcesRolled and self.board.hexTileDict[adjacentHex].robber == False): #This player gets a resource if hex is adjacent and no robber
                             resourceGenerated = self.board.hexTileDict[adjacentHex].resource.type
-                            player_i.resources[resourceGenerated] += 1
-                            print("{} collects 1 {} from Settlement".format(player_i.name, resourceGenerated))
+                            if self.board.withdraw_resource(resourceGenerated):
+                                player_i.resources[resourceGenerated] += 1
+                                print("{} collects 1 {} from Settlement".format(player_i.name, resourceGenerated))
                 
                 #Check each City the player has
                 for cityCoord in player_i.buildGraph['CITIES']:
                     for adjacentHex in self.board.boardGraph[cityCoord].adjacentHexList: #check each adjacent hex to a settlement
                         if(adjacentHex in hexResourcesRolled and self.board.hexTileDict[adjacentHex].robber == False): #This player gets a resource if hex is adjacent and no robber
                             resourceGenerated = self.board.hexTileDict[adjacentHex].resource.type
-                            player_i.resources[resourceGenerated] += 2
-                            print("{} collects 2 {} from City".format(player_i.name, resourceGenerated))
+                            gained = 0
+                            for _ in range(2):
+                                if self.board.withdraw_resource(resourceGenerated):
+                                    player_i.resources[resourceGenerated] += 1
+                                    gained += 1
+                            if gained:
+                                print("{} collects {} {} from City".format(player_i.name, gained, resourceGenerated))
 
                 print("Player:{}, Resources:{}, Points: {}".format(player_i.name, player_i.resources, player_i.victoryPoints))
                 #print('Dev Cards:{}'.format(player_i.devCards))
@@ -188,15 +194,13 @@ class catanGame():
         
         #Logic for a 7 roll
         else:
-            #Implement discarding cards
-            #Check for each player
+            #Implement discarding cards for each player
             for player_i in list(self.playerQueue.queue):
-                if(currentPlayer.isAI):
+                if player_i.isAI:
                     print("AI discarding resources...")
-                    #TO-DO
+                    player_i.heuristic_discard(self.board)
                 else:
-                    #Player must discard resources
-                    player_i.discardResources()
+                    player_i.discardResources(self.board)
 
             #Logic for robber
             if(currentPlayer.isAI):
@@ -398,5 +402,6 @@ class catanGame():
                 
 
 #Initialize new game and run
-newGame = catanGame()
-newGame.playCatan()
+if __name__ == '__main__':
+    newGame = catanGame()
+    newGame.playCatan()

--- a/code/heuristicAIPlayer.py
+++ b/code/heuristicAIPlayer.py
@@ -12,8 +12,8 @@ class heuristicAIPlayer(player):
     def updateAI(self): 
         self.isAI = True
         self.setupResources = [] #List to keep track of setup resources
-        #Initialize resources with just correct number needed for set up
-        self.resources = {'ORE':0, 'BRICK':4, 'WHEAT':2, 'WOOD':4, 'SHEEP':2} #Dictionary that keeps track of resource amounts
+        #Players start with no resources and collect them after initial setup
+        self.resources = {'ORE':0, 'BRICK':0, 'WHEAT':0, 'WOOD':0, 'SHEEP':0}
         print("Added new AI Player:", self.name)
 
 
@@ -71,7 +71,7 @@ class heuristicAIPlayer(player):
     def move(self, board):
         print("AI Player {} playing...".format(self.name))
         #Trade resources if there are excessive amounts of a particular resource
-        self.trade()
+        self.trade(board)
         #Build a settlements, city and few roads
         possibleVertices = board.get_potential_settlements(self)
         if(possibleVertices != {} and (self.resources['BRICK'] > 0 and self.resources['WOOD'] > 0 and self.resources['SHEEP'] > 0 and self.resources['WHEAT'] > 0)):
@@ -99,12 +99,12 @@ class heuristicAIPlayer(player):
         return
 
     #Wrapper function to control all trading
-    def trade(self):
+    def trade(self, board):
         for r1, r1_amount in self.resources.items():
             if(r1_amount >= 6): #heuristic to trade if a player has more than 5 of a particular resource
                 for r2, r2_amount in self.resources.items():
                     if(r2_amount < 1):
-                        self.trade_with_bank(r1, r2)
+                        self.trade_with_bank(r1, r2, board)
                         break
 
     
@@ -205,13 +205,28 @@ class heuristicAIPlayer(player):
             resourcesNeededDict['ORE'] = 3 - self.resources['ORE']
 
         if self.resources['WHEAT'] < 2:
-            resourcesNeededDict['ORE'] = 2 - self.resources['WHEAT']
+            resourcesNeededDict['WHEAT'] = 2 - self.resources['WHEAT']
 
         return resourcesNeededDict
 
-    def heuristic_discard(self):
+    def heuristic_discard(self, board):
         '''Function for the AI to choose a set of cards to discard upon rolling a 7
         '''
+        maxCards = 7
+        totalResourceCount = sum(self.resources.values())
+
+        if totalResourceCount > maxCards:
+            numCardsToDiscard = int(totalResourceCount/2)
+            print("\nAI Player {} has {} cards and discards {} cards".format(self.name, totalResourceCount, numCardsToDiscard))
+
+            for i in range(numCardsToDiscard):
+                resourceToDiscard = max(self.resources, key=lambda r: self.resources[r])
+                self.resources[resourceToDiscard] -= 1
+                board.deposit_resource(resourceToDiscard)
+                print("AI {} discarded a {}".format(self.name, resourceToDiscard))
+        else:
+            print("\nAI Player {} has {} cards and does not need to discard".format(self.name, totalResourceCount))
+
         return
 
     #Function to propose a trade -> give r1 and get r2

--- a/code/modelState.py
+++ b/code/modelState.py
@@ -34,4 +34,3 @@ class modelState():
 
 
 
-a = modelState()

--- a/code/player.py
+++ b/code/player.py
@@ -60,6 +60,8 @@ class player():
                 if not free:
                     self.resources['BRICK'] -= 1
                     self.resources['WOOD'] -= 1
+                    board.deposit_resource('BRICK')
+                    board.deposit_resource('WOOD')
 
                 board.updateBoardGraph_road(v1, v2, self) #update the overall boardGraph
 
@@ -95,6 +97,10 @@ class player():
                     self.resources['WOOD'] -= 1
                     self.resources['SHEEP'] -= 1
                     self.resources['WHEAT'] -= 1
+                    board.deposit_resource('BRICK')
+                    board.deposit_resource('WOOD')
+                    board.deposit_resource('SHEEP')
+                    board.deposit_resource('WHEAT')
                 
                 self.victoryPoints += 1
                 board.updateBoardGraph_settlement(vCoord, self) #update the overall boardGraph
@@ -124,6 +130,8 @@ class player():
                 #Update player resources
                 self.resources['ORE'] -= 3
                 self.resources['WHEAT'] -= 2
+                board.deposit_resource('ORE', 3)
+                board.deposit_resource('WHEAT', 2)
                 self.victoryPoints += 1
 
                 board.updateBoardGraph_city(vCoord, self) #update the overall boardGraph
@@ -278,6 +286,9 @@ class player():
             self.resources['ORE'] -= 1
             self.resources['WHEAT'] -= 1
             self.resources['SHEEP'] -= 1
+            board.deposit_resource('ORE')
+            board.deposit_resource('WHEAT')
+            board.deposit_resource('SHEEP')
 
             #If card is a victory point apply immediately, else add to new card list
             if(cardDrawn == 'VP'):
@@ -361,8 +372,10 @@ class player():
                 r1 = input("Enter resource 1 name: ").upper()
                 r2 = input("Enter resource 2 name: ").upper()
 
-            self.resources[r1] += 1
-            self.resources[r2] += 1
+            if game.board.withdraw_resource(r1):
+                self.resources[r1] += 1
+            if game.board.withdraw_resource(r2):
+                self.resources[r2] += 1
 
         if(devCardPlayed == 'MONOPOLY'):
             print("Resources to Monopolize:", resource_list)
@@ -382,7 +395,7 @@ class player():
 
 
     #Function to basic trade 4:1 with bank, or use ports to trade
-    def trade_with_bank(self, r1, r2):
+    def trade_with_bank(self, r1, r2, board):
         '''Function to implement trading with bank
         r1: resource player wants to trade away
         r2: resource player wants to receive
@@ -391,21 +404,33 @@ class player():
         #Get r1 port string
         r1_port = "2:1 " + r1
         if(r1_port in self.portList and self.resources[r1] >= 2): #Can use 2:1 port with r1
+            if not board.withdraw_resource(r2):
+                print("Bank lacks {} to trade".format(r2))
+                return
             self.resources[r1] -= 2
+            board.deposit_resource(r1, 2)
             self.resources[r2] += 1
             print("Traded 2 {} for 1 {} using {} Port".format(r1, r2, r1))
             return
 
         #Check for 3:1 Port
         elif('3:1 PORT' in self.portList and self.resources[r1] >= 3):
+            if not board.withdraw_resource(r2):
+                print("Bank lacks {} to trade".format(r2))
+                return
             self.resources[r1] -= 3
+            board.deposit_resource(r1, 3)
             self.resources[r2] += 1
             print("Traded 3 {} for 1 {} using 3:1 Port".format(r1, r2))
             return
 
         #Check 4:1 port
         elif(self.resources[r1] >= 4):
+            if not board.withdraw_resource(r2):
+                print("Bank lacks {} to trade".format(r2))
+                return
             self.resources[r1] -= 4
+            board.deposit_resource(r1, 4)
             self.resources[r2] += 1
             print("Traded 4 {} for 1 {}".format(r1, r2))
             return
@@ -438,7 +463,7 @@ class player():
 
             #Try and trade with Bank
             #Note: Ports and Error handling handled in trade with bank function
-            self.trade_with_bank(resourceToTrade, resourceToReceive) 
+            self.trade_with_bank(resourceToTrade, resourceToReceive, game.board)
             
             return
 
@@ -509,7 +534,7 @@ class player():
 
 
     #Function to discard cards
-    def discardResources(self):
+    def discardResources(self, board):
         '''Function to enable a player to select cards to discard when a 7 is rolled
         '''
         maxCards = 7 #Default is 7, but can be changed for testing
@@ -526,7 +551,7 @@ class player():
             
             #Loop to allow player to discard cards
             for i in range(numCardsToDiscard):
-                print("Player {} current resources to choose from:", self.resources)
+                print("Player {} current resources to choose from: {}".format(self.name, self.resources))
                 
                 resourceToDiscard = ''
                 while (resourceToDiscard not in self.resources.keys()) or (self.resources[resourceToDiscard] == 0):
@@ -534,6 +559,7 @@ class player():
 
                 #Discard that resource
                 self.resources[resourceToDiscard] -= 1
+                board.deposit_resource(resourceToDiscard)
                 print("Player {} discarded a {}, and needs to discard {} more cards".format(self.name, resourceToDiscard, (numCardsToDiscard-1-i)))
 
 


### PR DESCRIPTION
## Summary
- start AI players with no resources
- keep free placement in AI setup
- set KNIGHT cards to 14 instead of 15
- handle AI discarding with a new heuristic
- expand road search around owned settlements and cities
- correct resource key when evaluating city requirements
- wrap launch code in `if __name__ == '__main__':`
- remove stray instantiation from `modelState`
- add a resource bank so cards come from a limited supply
- adjust discard prompt formatting

## Testing
- `python3 -m py_compile code/board.py`
- `python3 -m py_compile code/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6853bb7e6518832588bb15a112b6e8d2