### PR TITLE
Handle empty resource list before stealing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea/
+.vscode/
+__pycache__/
+*.pyc
+notebooks/.ipynb_checkpoints/

--- a/code/AIGame.py
+++ b/code/AIGame.py
@@ -87,9 +87,12 @@ class catanAIGame():
             #check each adjacent hex to latest settlement
             for adjacentHex in self.board.boardGraph[player_i.buildGraph['SETTLEMENTS'][-1]].adjacentHexList:
                 resourceGenerated = self.board.hexTileDict[adjacentHex].resource.type
-                if(resourceGenerated != 'DESERT'):
+                if resourceGenerated != 'DESERT':
+                    self.board.withdraw_resource(resourceGenerated)
                     player_i.resources[resourceGenerated] += 1
-                    print("{} collects 1 {} from Settlement".format(player_i.name, resourceGenerated))
+                    print(
+                        "{} collects 1 {} from Settlement".format(
+                            player_i.name, resourceGenerated))
         
         pygame.time.delay(5000)
         self.gameSetup = False

--- a/code/catanGame.py
+++ b/code/catanGame.py
@@ -103,9 +103,12 @@ class catanGame():
             #check each adjacent hex to latest settlement
             for adjacentHex in self.board.boardGraph[player_i.buildGraph['SETTLEMENTS'][-1]].adjacentHexList:
                 resourceGenerated = self.board.hexTileDict[adjacentHex].resource.type
-                if(resourceGenerated != 'DESERT'):
+                if resourceGenerated != 'DESERT':
+                    self.board.withdraw_resource(resourceGenerated)
                     player_i.resources[resourceGenerated] += 1
-                    print("{} collects 1 {} from Settlement".format(player_i.name, resourceGenerated))
+                    print(
+                        "{} collects 1 {} from Settlement".format(
+                            player_i.name, resourceGenerated))
 
         self.gameSetup = False
 

--- a/code/player.py
+++ b/code/player.py
@@ -111,12 +111,15 @@ class player():
                 board.updateBoardGraph_settlement(vCoord, self) #update the overall boardGraph
 
                 print('{} Built a Settlement'.format(self.name))
-                return True
-                
-                 #Add port to players port list if it is a new port
-                if((board.boardGraph[vCoord].port != False) and (board.boardGraph[vCoord].port not in self.portList)):
+
+                # Add port to player's port list if it is a new port
+                if (board.boardGraph[vCoord].port and
+                        board.boardGraph[vCoord].port not in self.portList):
                     self.portList.append(board.boardGraph[vCoord].port)
-                    print("{} now has {} Port access".format(self.name, board.boardGraph[vCoord].port))
+                    print("{} now has {} Port access".format(
+                        self.name, board.boardGraph[vCoord].port))
+
+                return True
 
             else:
                 print("No settlements available to build")
@@ -172,10 +175,14 @@ class player():
             print("No Player on this hex to Rob")
             return
         
-        #Get all resources player 2 has in a list and use random list index to steal
+        # Get all resources player 2 has in a list and use random list index to steal
         p2_resources = []
         for resourceName, resourceAmount in player_2.resources.items():
-            p2_resources += [resourceName]*resourceAmount
+            p2_resources += [resourceName] * resourceAmount
+
+        if not p2_resources:
+            print("Player {} has no resources to steal".format(player_2.name))
+            return
 
         resourceIndexToSteal = np.random.randint(0, len(p2_resources))
 


### PR DESCRIPTION
## Summary
- ensure ports are added before returning from `Player.build_settlement`
- avoid `np.random.randint` crash when robbing a player with no resources
- withdraw setup resources from the bank before giving them to players
- add `.gitignore` for IDE files, compiled Python, and notebook checkpoints

## Testing
- `python -m py_compile code/player.py code/catanGame.py code/AIGame.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853cbce356c83258a1cb5f19808215c