### PR TITLE
Implement starting player dice rolls

### DIFF
--- a/code/AIGame.py
+++ b/code/AIGame.py
@@ -57,11 +57,35 @@ class catanAIGame():
     def build_initial_settlements(self):
         #Initialize new players with names and colors
         playerColors = ['black', 'darkslateblue', 'magenta4', 'orange1']
+        players = []
         for i in range(self.numPlayers):
             playerNameInput = input("Enter AI Player {} name: ".format(i+1))
             newPlayer = heuristicAIPlayer(playerNameInput, playerColors[i])
             newPlayer.updateAI()
-            self.playerQueue.put(newPlayer)
+            players.append(newPlayer)
+
+        contenders = players[:]
+        while True:
+            highest_roll = -1
+            highest_players = []
+            for p in contenders:
+                roll = np.random.randint(1,7) + np.random.randint(1,7)
+                print(f"{p.name} rolls {roll} for starting order")
+                if roll > highest_roll:
+                    highest_roll = roll
+                    highest_players = [p]
+                elif roll == highest_roll:
+                    highest_players.append(p)
+            if len(highest_players) == 1:
+                start_player = highest_players[0]
+                break
+            print("Tie for highest roll. Rolling again...")
+            contenders = highest_players
+
+        self.playerQueue.put(start_player)
+        for p in players:
+            if p != start_player:
+                self.playerQueue.put(p)
 
         playerList = list(self.playerQueue.queue)
 

--- a/code/catanGame.py
+++ b/code/catanGame.py
@@ -52,6 +52,7 @@ class catanGame():
         #Initialize new players with names and colors. Ask whether each
         #participant is human or AI and only create AI players when selected.
         playerColors = ['black', 'darkslateblue', 'magenta4', 'orange1']
+        players = []
         for i in range(self.numPlayers):
             playerName = input("Enter Player {} name: ".format(i + 1))
             ai_choice = ''
@@ -66,7 +67,30 @@ class catanGame():
             else:
                 new_player = player(playerName, playerColors[i])
 
-            self.playerQueue.put(new_player)
+            players.append(new_player)
+
+        contenders = players[:]
+        while True:
+            highest_roll = -1
+            highest_players = []
+            for p in contenders:
+                roll = np.random.randint(1,7) + np.random.randint(1,7)
+                print(f"{p.name} rolls {roll} for starting order")
+                if roll > highest_roll:
+                    highest_roll = roll
+                    highest_players = [p]
+                elif roll == highest_roll:
+                    highest_players.append(p)
+            if len(highest_players) == 1:
+                start_player = highest_players[0]
+                break
+            print("Tie for highest roll. Rolling again...")
+            contenders = highest_players
+
+        self.playerQueue.put(start_player)
+        for p in players:
+            if p != start_player:
+                self.playerQueue.put(p)
 
         playerList = list(self.playerQueue.queue)
 

--- a/code/modelState.py
+++ b/code/modelState.py
@@ -2,10 +2,12 @@
 #Model state class for AI training 
 # TO-DO
 
-from board import *
-from catanGame import *
-from player import *
-from heuristicAIPlayer import *
+"""Model state definitions for AI training."""
+
+# Avoid importing heavy modules at import time so this module can be
+# imported without side effects.
+
+from typing import Any
 
 class modelState():
     '''Define the variables needed by the RL model using a state and action object
@@ -29,8 +31,6 @@ class modelState():
         self.edgeState = [0]
 
         self.actionList = []
-
-        print("Array length", len(self.vertexState))
 
 
 

--- a/code/player.py
+++ b/code/player.py
@@ -526,9 +526,25 @@ class player():
 
             #Specify quantity to receive
             resource_received_amount = 0
-            while (resource_received_amount > playerToTrade.resources[resourceToReceive]) or (resource_received_amount < 1):
-                resource_received_amount = int(input("Enter quantity of {} to receive from player {}:".format(resourceToReceive, playerToTrade_name)))
+            while (
+                resource_received_amount > playerToTrade.resources[resourceToReceive]
+                or resource_received_amount < 1
+            ):
+                resource_received_amount = int(
+                    input(
+                        "Enter quantity of {} to receive from player {}:".format(
+                            resourceToReceive, playerToTrade_name
+                        )
+                    )
+                )
 
+            #Confirm trade with the other player before executing
+            confirmation = input(
+                f"{playerToTrade_name}, do you accept {self.name}'s offer of {resource_traded_amount} {resourceToTrade} for {resource_received_amount} {resourceToReceive}? (y/n): "
+            ).strip().lower()
+            if confirmation != 'y':
+                print(f"{playerToTrade_name} declined the trade")
+                return
 
             #Execute trade - player gives resource traded and gains resource received
             self.resources[resourceToReceive] += resource_received_amount
@@ -538,8 +554,16 @@ class player():
             playerToTrade.resources[resourceToReceive] -= resource_received_amount
             playerToTrade.resources[resourceToTrade] += resource_traded_amount
 
-            print("Player {} successfully traded {} {} for {} {} with player {}".format(self.name, resource_traded_amount, resourceToTrade,
-                                                                                        resource_received_amount, resourceToReceive, playerToTrade_name))
+            print(
+                "Player {} successfully traded {} {} for {} {} with player {}".format(
+                    self.name,
+                    resource_traded_amount,
+                    resourceToTrade,
+                    resource_received_amount,
+                    resourceToReceive,
+                    playerToTrade_name,
+                )
+            )
 
             return 
 


### PR DESCRIPTION
## Summary
- let each player roll two dice before setup
- reorder queue so the highest roll starts
- prompt other player to confirm trades before exchanging resources
- remove print from modelState and avoid side effects on import

## Testing
- `python -m py_compile code/catanGame.py code/AIGame.py code/player.py code/modelState.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853d56cffdc832597905a6decb3a3c1