### PR TITLE
Fix largest army update for AI turn

### DIFF
--- a/code/AIGame.py
+++ b/code/AIGame.py
@@ -256,6 +256,8 @@ class catanAIGame():
                     currPlayer.move(self.board, self) #AI Player makes all its moves
                     #Check if AI player gets longest road and update Victory points
                     self.check_longest_road(currPlayer)
+                    #Also update Largest Army status in case a knight was played
+                    self.check_largest_army(currPlayer)
                     print("Player:{}, Resources:{}, Points: {}".format(currPlayer.name, currPlayer.resources, currPlayer.victoryPoints))
                     
                     self.boardView.displayGameScreen()#Update back to original gamescreen


### PR DESCRIPTION
## Summary
- update AI game loop to check largest army after each AI turn

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853da798a5083258179abd7b5f62426