### PR TITLE
Add interactive trading UI

### DIFF
--- a/code/catanGame.py
+++ b/code/catanGame.py
@@ -494,31 +494,38 @@ class catanGame():
 
                                 #Check if player wants to trade with the bank
                                 if(self.boardView.tradeBank_button.collidepoint(e.pos)):
-                                    if(diceRolled == True):
-                                        currPlayer.initiate_trade(self, 'BANK')
-                                        #Show updated points and resources
-                                        print(
-                                            "Player:{}, Resources:{}, Points: {}".format(
-                                                currPlayer.name,
-                                                currPlayer.resources,
-                                                currPlayer.visibleVictoryPoints,
+                                    if diceRolled:
+                                        choice = self.boardView.trade_bank_display(currPlayer)
+                                        if choice:
+                                            r1, r2 = choice
+                                            currPlayer.trade_with_bank(r1, r2, self.board)
+                                            self.boardView.displayGameScreen()
+                                            print(
+                                                "Player:{}, Resources:{}, Points: {}".format(
+                                                    currPlayer.name,
+                                                    currPlayer.resources,
+                                                    currPlayer.visibleVictoryPoints,
+                                                )
                                             )
-                                        )
                                     else:
                                         print("You must roll the dice before trading with the bank.")
                                 
                                 #Check if player wants to trade with another player
                                 if(self.boardView.tradePlayers_button.collidepoint(e.pos)):
-                                    if(diceRolled == True):
-                                        currPlayer.initiate_trade(self, 'PLAYER')
-                                        #Show updated points and resources
-                                        print(
-                                            "Player:{}, Resources:{}, Points: {}".format(
-                                                currPlayer.name,
-                                                currPlayer.resources,
-                                                currPlayer.visibleVictoryPoints,
+                                    if diceRolled:
+                                        others = [p for p in list(self.playerQueue.queue) if p != currPlayer]
+                                        result = self.boardView.trade_players_display(currPlayer, others)
+                                        if result:
+                                            other_p, r1, r2 = result
+                                            currPlayer.trade_with_player(other_p, r1, r2)
+                                            self.boardView.displayGameScreen()
+                                            print(
+                                                "Player:{}, Resources:{}, Points: {}".format(
+                                                    currPlayer.name,
+                                                    currPlayer.resources,
+                                                    currPlayer.visibleVictoryPoints,
+                                                )
                                             )
-                                        )
                                     else:
                                         print("You must roll the dice before trading with other players.")
 

--- a/code/gameView.py
+++ b/code/gameView.py
@@ -359,5 +359,167 @@ class catanGameView():
             for e in pygame.event.get(): 
                 if(e.type == pygame.MOUSEBUTTONDOWN): #Exit this loop on mouseclick
                     for playerToRob, playerCircleRect in possiblePlayerDict.items():
-                        if(playerCircleRect.collidepoint(e.pos)): 
+                        if(playerCircleRect.collidepoint(e.pos)):
                             return playerToRob
+
+    # ------------------------- Trading Screens -------------------------
+    def trade_bank_display(self, player):
+        """Display screen to select resources for trading with the bank.
+
+        Returns a tuple ``(resource_give, resource_get)`` or ``None`` if
+        the trade was cancelled.
+        """
+        self.displayGameScreen()
+
+        resources = ['BRICK', 'WOOD', 'WHEAT', 'SHEEP', 'ORE']
+        colorDict_RGB = {
+            'BRICK': (255, 51, 51),
+            'ORE': (128, 128, 128),
+            'WHEAT': (255, 255, 51),
+            'WOOD': (0, 153, 0),
+            'SHEEP': (51, 255, 51),
+        }
+
+        give_rects = {}
+        recv_rects = {}
+
+        give_text = self.font_button.render('Give to Bank', False, (0, 0, 0))
+        recv_text = self.font_button.render('Receive', False, (0, 0, 0))
+        cancel_rect = pygame.Rect(500, 40, 80, 30)
+        cancel_text = self.font_button.render('CANCEL', False, (0, 0, 0))
+
+        for i, r in enumerate(resources):
+            give_rects[r] = pygame.Rect(180 + i * 80, 150, 60, 30)
+            recv_rects[r] = pygame.Rect(180 + i * 80, 250, 60, 30)
+
+        selecting_give = True
+        give_choice = None
+        recv_choice = None
+
+        while True:
+            self.displayGameScreen()
+            self.screen.blit(give_text, (180, 120))
+            self.screen.blit(recv_text, (180, 220))
+            pygame.draw.rect(self.screen, pygame.Color('gray70'), cancel_rect)
+            self.screen.blit(cancel_text, (cancel_rect.x + 5, cancel_rect.y + 5))
+
+            for r, rect in give_rects.items():
+                pygame.draw.rect(self.screen, pygame.Color(*colorDict_RGB[r]), rect)
+                text = self.font_button.render(r, False, (0, 0, 0))
+                self.screen.blit(text, (rect.x + 2, rect.y + 5))
+                if give_choice == r:
+                    pygame.draw.rect(self.screen, pygame.Color('gold'), rect, 3)
+
+            for r, rect in recv_rects.items():
+                pygame.draw.rect(self.screen, pygame.Color(*colorDict_RGB[r]), rect)
+                text = self.font_button.render(r, False, (0, 0, 0))
+                self.screen.blit(text, (rect.x + 2, rect.y + 5))
+                if recv_choice == r:
+                    pygame.draw.rect(self.screen, pygame.Color('gold'), rect, 3)
+
+            pygame.display.update()
+
+            for e in pygame.event.get():
+                if e.type == pygame.MOUSEBUTTONDOWN:
+                    if cancel_rect.collidepoint(e.pos):
+                        return None
+                    if selecting_give:
+                        for r, rect in give_rects.items():
+                            if rect.collidepoint(e.pos):
+                                give_choice = r
+                                selecting_give = False
+                                break
+                    else:
+                        for r, rect in recv_rects.items():
+                            if rect.collidepoint(e.pos) and r != give_choice:
+                                recv_choice = r
+                                return give_choice, recv_choice
+
+    def trade_players_display(self, player, other_players):
+        """Display screen to trade with another player.
+
+        ``other_players`` is a list of player objects available for trade.
+        Returns ``(player_obj, give_resource, receive_resource)`` or ``None`` if
+        cancelled.
+        """
+        if not other_players:
+            return None
+
+        resources = ['BRICK', 'WOOD', 'WHEAT', 'SHEEP', 'ORE']
+        colorDict_RGB = {
+            'BRICK': (255, 51, 51),
+            'ORE': (128, 128, 128),
+            'WHEAT': (255, 255, 51),
+            'WOOD': (0, 153, 0),
+            'SHEEP': (51, 255, 51),
+        }
+
+        player_rects = {}
+        give_rects = {}
+        recv_rects = {}
+
+        cancel_rect = pygame.Rect(500, 40, 80, 30)
+        cancel_text = self.font_button.render('CANCEL', False, (0, 0, 0))
+
+        for i, p in enumerate(other_players):
+            player_rects[p] = pygame.Rect(180 + i * 100, 120, 80, 30)
+
+        for i, r in enumerate(resources):
+            give_rects[r] = pygame.Rect(180 + i * 80, 200, 60, 30)
+            recv_rects[r] = pygame.Rect(180 + i * 80, 300, 60, 30)
+
+        step = 'player'
+        player_choice = None
+        give_choice = None
+        recv_choice = None
+
+        while True:
+            self.displayGameScreen()
+            pygame.draw.rect(self.screen, pygame.Color('gray70'), cancel_rect)
+            self.screen.blit(cancel_text, (cancel_rect.x + 5, cancel_rect.y + 5))
+
+            for p, rect in player_rects.items():
+                pygame.draw.rect(self.screen, pygame.Color('lightblue'), rect)
+                text = self.font_button.render(p.name, False, (0, 0, 0))
+                self.screen.blit(text, (rect.x + 2, rect.y + 5))
+                if player_choice == p:
+                    pygame.draw.rect(self.screen, pygame.Color('gold'), rect, 3)
+
+            for r, rect in give_rects.items():
+                pygame.draw.rect(self.screen, pygame.Color(*colorDict_RGB[r]), rect)
+                text = self.font_button.render(r, False, (0, 0, 0))
+                self.screen.blit(text, (rect.x + 2, rect.y + 5))
+                if give_choice == r:
+                    pygame.draw.rect(self.screen, pygame.Color('gold'), rect, 3)
+
+            for r, rect in recv_rects.items():
+                pygame.draw.rect(self.screen, pygame.Color(*colorDict_RGB[r]), rect)
+                text = self.font_button.render(r, False, (0, 0, 0))
+                self.screen.blit(text, (rect.x + 2, rect.y + 5))
+                if recv_choice == r:
+                    pygame.draw.rect(self.screen, pygame.Color('gold'), rect, 3)
+
+            pygame.display.update()
+
+            for e in pygame.event.get():
+                if e.type == pygame.MOUSEBUTTONDOWN:
+                    if cancel_rect.collidepoint(e.pos):
+                        return None
+                    if step == 'player':
+                        for p, rect in player_rects.items():
+                            if rect.collidepoint(e.pos):
+                                player_choice = p
+                                step = 'give'
+                                break
+                    elif step == 'give':
+                        for r, rect in give_rects.items():
+                            if rect.collidepoint(e.pos):
+                                give_choice = r
+                                step = 'receive'
+                                break
+                    else:
+                        for r, rect in recv_rects.items():
+                            if rect.collidepoint(e.pos) and r != give_choice:
+                                recv_choice = r
+                                return player_choice, give_choice, recv_choice
+

--- a/code/player.py
+++ b/code/player.py
@@ -485,6 +485,28 @@ class player():
             print("Insufficient resource {} to trade with Bank".format(r1))
             return
 
+    def trade_with_player(self, other_player, r1, r2):
+        """Execute a simple 1-for-1 trade with ``other_player``.
+
+        ``r1`` is the resource this player gives and ``r2`` is the resource
+        received from ``other_player``.  Returns ``True`` if the trade succeeds.
+        """
+        if self.resources.get(r1, 0) < 1:
+            print(f"Insufficient {r1} to trade with {other_player.name}")
+            return False
+        if other_player.resources.get(r2, 0) < 1:
+            print(f"{other_player.name} lacks {r2} to trade")
+            return False
+
+        self.resources[r1] -= 1
+        self.resources[r2] += 1
+        other_player.resources[r2] -= 1
+        other_player.resources[r1] += 1
+        print(
+            f"{self.name} traded 1 {r1} for 1 {r2} with {other_player.name}"
+        )
+        return True
+
 
     #Function to initate a trade - with bank or other players
     def initiate_trade(self, game, trade_type):


### PR DESCRIPTION
## Summary
- implement trade screens in `gameView.py`
- allow simple bank and player trades via new UI
- refresh board after trades and adjust state handling
- add helper `trade_with_player` to player class

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854290531ec8325bda0d1b05926523d