### PR TITLE
Implement hex tile neighbor initialization

### DIFF
--- a/code/board.py
+++ b/code/board.py
@@ -58,6 +58,10 @@ class catanBoard(hexTile, Vertex):
             self.hexTileDict[hexIndex_i] = newHexTile
             hexIndex_i += 1
 
+        # After all tiles are created, populate each tile's neighbor list
+        for tile in self.hexTileDict.values():
+            tile.updateNeighbors(self.hexTileDict)
+
         # Place the number discs following the A-B-C order
         self.place_number_discs()
 

--- a/code/hexTile.py
+++ b/code/hexTile.py
@@ -23,7 +23,30 @@ class hexTile():
         self.robber = False
 
     #Function to update hex neighbors
-    def updateNeighbors(self):  
+    def updateNeighbors(self, board_hexes):
+        """Populate ``neighborList`` with adjacent hex tiles.
+
+        Parameters
+        ----------
+        board_hexes : dict
+            Mapping of ``hexIndex`` to ``hexTile`` for all tiles on the board.
+        """
+
+        neighbors = []
+        # Iterate over the six possible directions around this hex
+        for direction in range(6):
+            n_hex = hex_neighbor(self.hex, direction)
+            n_coord = Axial_Point(n_hex.q, n_hex.r)
+
+            # Find the tile with these axial coordinates, if it exists
+            for tile in board_hexes.values():
+                if tile.index == self.index:
+                    continue
+                if tile.coord == n_coord:
+                    neighbors.append(tile)
+                    break
+
+        self.neighborList = neighbors
         return None
 
 


### PR DESCRIPTION
## Summary
- implement calculation of neighbouring hexes in `updateNeighbors`
- call `updateNeighbors` for each tile when creating the board

## Testing
- `python -m compileall -q code/hexTile.py code/board.py`
- `python - <<'PY'
import sys
sys.path.insert(0,'code')
from board import catanBoard
PY
` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68542d55d45883259794933dc9a1d2c2