### PR TITLE
Add basic pytest suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+# Use stub modules for numpy and pygame before importing game code
+STUB_DIR = os.path.join(os.path.dirname(__file__), 'stubs')
+sys.path.insert(0, STUB_DIR)
+
+# Add code directory to path
+CODE_DIR = os.path.join(os.path.dirname(__file__), '..', 'code')
+sys.path.insert(0, os.path.abspath(CODE_DIR))
+
+# Ensure pygame does not require a display
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')

--- a/tests/stubs/numpy/__init__.py
+++ b/tests/stubs/numpy/__init__.py
@@ -1,0 +1,19 @@
+import random as _random
+
+class _Random:
+    def permutation(self, seq):
+        seq = list(seq)
+        _random.shuffle(seq)
+        return seq
+
+    def randint(self, low, high=None):
+        if high is None:
+            high = low
+            low = 0
+        # numpy randint is [low, high)
+        return _random.randint(low, high - 1)
+
+    def choice(self, seq):
+        return _random.choice(seq)
+
+random = _Random()

--- a/tests/stubs/pygame/__init__.py
+++ b/tests/stubs/pygame/__init__.py
@@ -1,0 +1,4 @@
+# Minimal pygame stub for testing
+
+def init():
+    pass

--- a/tests/test_bank.py
+++ b/tests/test_bank.py
@@ -1,0 +1,10 @@
+from board import catanBoard
+
+
+def test_bank_withdraw_deposit():
+    board = catanBoard()
+    assert board.withdraw_resource('ORE', 1) is True
+    assert board.resourceBank['ORE'] == 18
+    assert board.withdraw_resource('ORE', 100) is False
+    board.deposit_resource('ORE', 2)
+    assert board.resourceBank['ORE'] == 20

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1,0 +1,20 @@
+import os
+from board import catanBoard
+from hexTile import Resource
+
+
+def test_board_initialization():
+    board = catanBoard()
+    assert len(board.hexTileDict) == 19
+
+    deserts = [t for t in board.hexTileDict.values() if t.resource.type == 'DESERT']
+    assert len(deserts) == 1
+    assert deserts[0].robber is True
+
+    numbers = [t.resource.num for t in board.hexTileDict.values()
+               if t.resource.type != 'DESERT']
+    expected = [5, 2, 6, 3, 8, 10, 9, 12, 11, 4, 8, 10, 9, 4, 5, 6, 3, 11]
+    assert sorted(numbers) == sorted(expected)
+
+    for tile in board.hexTileDict.values():
+        assert tile.neighborList is not None

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,25 @@
+from board import catanBoard
+from player import player
+
+
+def test_player_build_methods():
+    board = catanBoard()
+    p = player('P1', 'red')
+
+    v1 = list(board.boardGraph.keys())[0]
+    v2 = board.boardGraph[v1].edgeList[0]
+
+    p.build_road(v1, v2, board, free=True)
+    assert (v1, v2) in p.buildGraph['ROADS']
+    idx = board.boardGraph[v1].edgeList.index(v2)
+    assert board.boardGraph[v1].edgeState[idx][1] is True
+
+    p.build_settlement(v1, board, free=True)
+    assert v1 in p.buildGraph['SETTLEMENTS']
+    assert board.boardGraph[v1].state['Settlement'] is True
+
+    p.resources['ORE'] = 3
+    p.resources['WHEAT'] = 2
+    p.build_city(v1, board)
+    assert v1 in p.buildGraph['CITIES']
+    assert board.boardGraph[v1].state['City'] is True

--- a/tests/test_devcards.py
+++ b/tests/test_devcards.py
@@ -1,0 +1,32 @@
+from board import catanBoard
+from player import player
+from hexTile import Resource
+
+
+def test_draw_and_update_dev_cards():
+    board = catanBoard()
+    board.devCardStack = {'KNIGHT': 1}
+    p = player('P1', 'blue')
+    p.resources['ORE'] = 1
+    p.resources['WHEAT'] = 1
+    p.resources['SHEEP'] = 1
+
+    p.draw_devCard(board)
+    assert board.devCardStack['KNIGHT'] == 0
+    assert p.newDevCards == ['KNIGHT']
+    p.updateDevCards()
+    assert p.devCards['KNIGHT'] == 1
+
+
+def test_draw_vp_card():
+    board = catanBoard()
+    board.devCardStack = {'VP': 1}
+    p = player('P2', 'green')
+    p.resources['ORE'] = 1
+    p.resources['WHEAT'] = 1
+    p.resources['SHEEP'] = 1
+
+    p.draw_devCard(board)
+    assert board.devCardStack['VP'] == 0
+    assert p.victoryPoints == 1
+    assert p.devCards['VP'] == 1


### PR DESCRIPTION
## Summary
- add pytest configuration with custom stubs for `numpy` and `pygame`
- test board initialization
- test bank withdrawals and deposits
- test player building methods
- test development card drawing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68542d6918d08325b5509ce6db06e1f2