### PR TITLE
Fix board info method to use tile dict

### DIFF
--- a/code/board.py
+++ b/code/board.py
@@ -236,7 +236,7 @@ class catanBoard(hexTile, Vertex):
     
     #Function to Display Catan Board Info
     def displayBoardInfo(self):
-        for tile in self.hexTileList.values():
+        for tile in self.hexTileDict.values():
             tile.displayHexInfo()
         return None
 


### PR DESCRIPTION
## Summary
- fix reference to tile container in `displayBoardInfo`
- ensure test suite still passes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854372e1a308325b593a11d7f8d4a6f